### PR TITLE
chore (#2): Configuração do CORS no backend

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.compile.nullAnalysis.mode": "automatic"
-}

--- a/porygon/src/main/java/fatec/porygon/config/CorsConfig.java
+++ b/porygon/src/main/java/fatec/porygon/config/CorsConfig.java
@@ -7,17 +7,17 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class CorsConfig {
-
     @Bean
     public WebMvcConfigurer corsConfigurer() {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
-                        .allowedOrigins("http://localhost:3000") // Substituir pelo endereço do frontend
+                        .allowedOrigins("http://localhost:5173") // Frontend Vue URL
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                         .allowedHeaders("*")
-                        .allowCredentials(true);
+                        .allowCredentials(true)
+                        .maxAge(3600); // Cache CORS por 1 hora
             }
         };
     }

--- a/porygon/src/main/resources/application.properties
+++ b/porygon/src/main/resources/application.properties
@@ -2,7 +2,7 @@ spring.application.name=Porygon
 
 spring.datasource.url=jdbc:mysql://localhost:3306/porygon?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
 spring.datasource.username=root
-spring.datasource.password=root
+spring.datasource.password=pesquisador
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=none
@@ -15,8 +15,16 @@ spring.thymeleaf.mode=HTML
 spring.thymeleaf.encoding=UTF-8
 spring.thymeleaf.cache=false
 
+# Server configuration
+server.port=${BACKEND_PORT:8080}
+
+# CORS configuration
+spring.mvc.cors.allowed-origins=http://localhost:5173
+spring.mvc.cors.allowed-methods=GET,POST,PUT,DELETE,OPTIONS
+spring.mvc.cors.allowed-headers=*
+spring.mvc.cors.allow-credentials=true
+
+# Security configuration
 spring.security.user.name=admin
 spring.security.user.password=12345
 spring.security.user.roles=USER
-
-


### PR DESCRIPTION
- Configuração do CORS no backend para permitir requisições entre domínios.
- Atualização baseada na branch Sprint-1.
- Testado e validado localmente.
- Necessário adicionar arquivo ".env" na raiz do projeto com o conteúdo
- "VITE_BACKEND_URL=http://localhost:8080
VITE_FRONTEND_URL=http://localhost:5173" 