### PR TITLE
feat (#52): Prepara o ambiente desde o banco e metodo para asssociar um usuario existente a um talhao 

### DIFF
--- a/banco/schema.sql
+++ b/banco/schema.sql
@@ -74,10 +74,12 @@ CREATE TABLE talhao (
     area DOUBLE PRECISION NOT NULL,
     tipo_solo_id INT,
     area_agricola_id INT,
+    usuario_analista_id INT,
     arquivo_daninha GEOMETRY,
     arquivo_final_daninha GEOMETRY,
     FOREIGN KEY (tipo_solo_id) REFERENCES tipo_solo(id),
-    FOREIGN KEY (area_agricola_id) REFERENCES area_agricola(id)
+    FOREIGN KEY (area_agricola_id) REFERENCES area_agricola(id),
+    FOREIGN KEY (usuario_analista_id) REFERENCES usuario(id)
 );
 
 -- Tabela safra (depende de cultura e talhao)

--- a/src/main/java/fatec/porygon/controller/TalhaoController.java
+++ b/src/main/java/fatec/porygon/controller/TalhaoController.java
@@ -1,0 +1,23 @@
+package fatec.porygon.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import fatec.porygon.service.TalhaoService;
+
+@RestController
+@RequestMapping("/talhoes")
+public class TalhaoController {
+
+    private final TalhaoService talhaoService;
+
+    public TalhaoController(TalhaoService talhaoService) {
+        this.talhaoService = talhaoService;
+    }
+
+    @PostMapping("/atribuir-analista")
+    public ResponseEntity<String> atribuirAnalistaAoTalhao(@RequestParam Long talhaoId,
+                                                           @RequestParam Long usuarioAnalistaId) {
+        talhaoService.atribuirAnalista(talhaoId, usuarioAnalistaId);
+        return ResponseEntity.ok("Analista atribuído com sucesso.");
+    }
+}

--- a/src/main/java/fatec/porygon/entity/Talhao.java
+++ b/src/main/java/fatec/porygon/entity/Talhao.java
@@ -35,6 +35,10 @@ import java.util.List;
         @OneToMany(mappedBy = "talhao")
         private List<Safra> safras = new ArrayList<>();
 
+        @ManyToOne
+        @JoinColumn(name = "usuario_analista_id")
+        private Usuario usuarioAnalista;
+
     public Double getArea() {return area;}
     public void setArea(Double area) {this.area = area;}
 
@@ -58,5 +62,7 @@ import java.util.List;
 
     public TipoSolo getTipo_solo() {return tipo_solo;}
     public void setTipo_solo(TipoSolo tipo_solo) {this.tipo_solo = tipo_solo;}
-}
 
+    public Usuario getUsuarioAnalista() { return usuarioAnalista; }
+    public void setUsuarioAnalista(Usuario usuarioAnalista) { this.usuarioAnalista = usuarioAnalista; }
+}

--- a/src/main/java/fatec/porygon/repository/TalhaoRepository.java
+++ b/src/main/java/fatec/porygon/repository/TalhaoRepository.java
@@ -1,0 +1,10 @@
+package fatec.porygon.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import fatec.porygon.entity.Talhao;
+
+@Repository
+public interface TalhaoRepository extends JpaRepository<Talhao, Long> {
+
+}

--- a/src/main/java/fatec/porygon/service/TalhaoService.java
+++ b/src/main/java/fatec/porygon/service/TalhaoService.java
@@ -1,0 +1,33 @@
+package fatec.porygon.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import fatec.porygon.entity.Talhao;
+import fatec.porygon.entity.Usuario;
+import fatec.porygon.repository.TalhaoRepository;
+import fatec.porygon.repository.UsuarioRepository;
+
+@Service
+public class TalhaoService {
+
+    @Autowired
+    private TalhaoRepository talhaoRepository;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    public void atribuirAnalista(Long talhaoId, Long usuarioAnalistaId) {
+        Talhao talhao = talhaoRepository.findById(talhaoId)
+                .orElseThrow(() -> new RuntimeException("Talhão não encontrado."));
+        Usuario analista = usuarioRepository.findById(usuarioAnalistaId)
+                .orElseThrow(() -> new RuntimeException("Usuário analista não encontrado."));
+
+        if (talhao.getUsuarioAnalista() != null &&
+            talhao.getUsuarioAnalista().getId().equals(usuarioAnalistaId)) {
+            throw new RuntimeException("Este talhão já está associado a esse analista.");
+        }
+
+        talhao.setUsuarioAnalista(analista);
+        talhaoRepository.save(talhao);
+    }
+}


### PR DESCRIPTION
#52 

Abra o Postman

Configure a Requisição
Método HTTP: POST
URL: http://localhost:8080/talhoes/atribuir-analista

Tipo de Body: x-www-form-urlencoded
Parâmetros no Body:
talhaoId: ID do talhão que será associado ao analista (exemplo: 1).
usuarioAnalistaId: ID do analista que será associado ao talhão (exemplo: 2).

Exemplo de Configuração no Postman
Vá para a aba Body.
Selecione a opção x-www-form-urlencoded.
Adicione os seguintes campos:
Key: talhaoId | Value: 1
Key: usuarioAnalistaId | Value: 2

Envie a Requisição
Clique no botão Send.
Aguarde a resposta do servidor.

Verifique a Resposta
Resposta esperada (200 OK):

Possíveis Erros:

404 Not Found: Caso o talhaoId ou usuarioAnalistaId não existam no banco.
ou
400 Bad Request: Caso algum parâmetro esteja faltando.

Verifique o Banco de Dados
Após a requisição bem-sucedida, confirme que o talhão foi atualizado no banco de dados.
Consulta SQL:
Resultado esperado:
A coluna usuario_analista_id deve conter o ID do analista (2).

Com isso, você terá testado a funcionalidade de associação do analista ao talhão usando o Postman.