### PR TITLE
refactor (#43): métodos de conversão Geometry-GeoJson em Utils

### DIFF
--- a/src/main/java/fatec/porygon/service/AreaAgricolaService.java
+++ b/src/main/java/fatec/porygon/service/AreaAgricolaService.java
@@ -3,15 +3,11 @@ package fatec.porygon.service;
 import fatec.porygon.dto.AreaAgricolaDto;
 import fatec.porygon.entity.AreaAgricola;
 import fatec.porygon.entity.Cidade;
-import fatec.porygon.entity.Usuario;
 import fatec.porygon.enums.StatusArea;
 import fatec.porygon.repository.AreaAgricolaRepository;
-import fatec.porygon.repository.UsuarioRepository;
-import main.java.fatec.porygon.utils.ConvertGeoJsonUtils;
+import fatec.porygon.utils.ConvertGeoJsonUtils;
 
 import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.io.geojson.GeoJsonReader;
-import org.locationtech.jts.io.geojson.GeoJsonWriter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/fatec/porygon/service/AreaAgricolaService.java
+++ b/src/main/java/fatec/porygon/service/AreaAgricolaService.java
@@ -7,6 +7,8 @@ import fatec.porygon.entity.Usuario;
 import fatec.porygon.enums.StatusArea;
 import fatec.porygon.repository.AreaAgricolaRepository;
 import fatec.porygon.repository.UsuarioRepository;
+import main.java.fatec.porygon.utils.ConvertGeoJsonUtils;
+
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.geojson.GeoJsonReader;
 import org.locationtech.jts.io.geojson.GeoJsonWriter;
@@ -23,6 +25,7 @@ public class AreaAgricolaService {
 
     private final AreaAgricolaRepository areaAgricolaRepository;
     private final CidadeService cidadeService;
+    private final ConvertGeoJsonUtils conversorGeoJson = new ConvertGeoJsonUtils();
 
     @Autowired
     public AreaAgricolaService(AreaAgricolaRepository areaAgricolaRepository,
@@ -102,8 +105,7 @@ public class AreaAgricolaService {
         // Conversão de GeoJSON para Geometry
         if (dto.getArquivoFazenda() != null && !dto.getArquivoFazenda().isEmpty()) {
             try {
-                GeoJsonReader reader = new GeoJsonReader();
-                Geometry geometry = reader.read(dto.getArquivoFazenda());
+                Geometry geometry = conversorGeoJson.convertGeoJsonToGeometry(dto.getArquivoFazenda());
                 areaAgricola.setArquivoFazenda(geometry);
             } catch (Exception e) {
                 throw new RuntimeException("Erro ao processar o arquivo GeoJSON", e);
@@ -140,8 +142,7 @@ public class AreaAgricolaService {
         
         // Conversão de Geometry para GeoJSON
         if (areaAgricola.getArquivoFazenda() != null) {
-            GeoJsonWriter writer = new GeoJsonWriter();
-            String geoJson = writer.write(areaAgricola.getArquivoFazenda());
+            String geoJson = conversorGeoJson.convertGeometryToGeoJson(areaAgricola.getArquivoFazenda());
             dto.setArquivoFazenda(geoJson);
         }
         

--- a/src/main/java/fatec/porygon/utils/ConvertGeoJsonUtils.java
+++ b/src/main/java/fatec/porygon/utils/ConvertGeoJsonUtils.java
@@ -1,0 +1,36 @@
+package main.java.fatec.porygon.utils;
+
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.geojson.GeoJsonReader;
+import org.locationtech.jts.io.geojson.GeoJsonWriter;
+
+public class ConvertGeoJsonUtils {
+
+    public Geometry convertGeoJsonToGeometry(String geoJson) {
+        GeoJsonReader geoJsonReader = new GeoJsonReader();
+
+        if (geoJson == null || geoJson.trim().isEmpty()) {
+            return null;
+        }
+
+        try {
+            return geoJsonReader.read(geoJson);
+        } catch (ParseException e) {
+            throw new RuntimeException("Erro ao converter GeoJSON para Geometry: " + e.getMessage(), e);
+        }
+
+    }
+
+    public String convertGeometryToGeoJson(Geometry geometry) {
+
+        GeoJsonWriter geoJsonWriter = new GeoJsonWriter();
+
+        if (geometry == null) {
+            return null;
+        }
+
+        return geoJsonWriter.write(geometry);
+    }
+
+}

--- a/src/main/java/fatec/porygon/utils/ConvertGeoJsonUtils.java
+++ b/src/main/java/fatec/porygon/utils/ConvertGeoJsonUtils.java
@@ -1,4 +1,4 @@
-package main.java.fatec.porygon.utils;
+package fatec.porygon.utils;
 
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.ParseException;


### PR DESCRIPTION
#43 

Implementar o fluxo completo de manipulação de dados GeoJSON no backend, garantindo a persistência no banco e a conversão adequada para exibição no front-end.

Foi criada a classe a ser reutilizada e a implatação da mesma no service de area-agricola

Para validação do teste é necessário chamar as rotas de area-agricola, que devem apresentar o mesmo resultado antes e depois das alterações dessa branch