### PR TITLE
feat(#59): adicionar colunas de data na tabela talhao e atualizar o backend

### DIFF
--- a/src/main/java/fatec/porygon/entity/Safra.java
+++ b/src/main/java/fatec/porygon/entity/Safra.java
@@ -74,9 +74,9 @@ public class Safra {
     public Usuario getUsuarioAnalista() { return usuarioAnalista; }
     public void setUsuarioAnalista(Usuario usuarioAnalista) { this.usuarioAnalista = usuarioAnalista; }
 
-    public LocalDateTime getDataUltimaVersao() {return dataUltimaVersao;}
-    public void setDataUltimaVersao(LocalDateTime dataUltimaVersao) {this.dataUltimaVersao = dataUltimaVersao;}
+    public LocalDateTime getDataCadastro() { return dataCadastro; }
+    public void setDataCadastro(LocalDateTime dataCadastro) { this.dataCadastro = dataCadastro; }
 
-    public LocalDateTime getDataCadastro() {return dataCadastro;}
-    public void setDataCadastro(LocalDateTime dataCadastro) {this.dataCadastro = dataCadastro;}
+    public LocalDateTime getDataUltimaVersao() { return dataUltimaVersao; }
+    public void setDataUltimaVersao(LocalDateTime dataUltimaVersao) { this.dataUltimaVersao = dataUltimaVersao; }
 }

--- a/src/main/java/fatec/porygon/service/AreaAgricolaService.java
+++ b/src/main/java/fatec/porygon/service/AreaAgricolaService.java
@@ -3,8 +3,10 @@ package fatec.porygon.service;
 import fatec.porygon.dto.AreaAgricolaDto;
 import fatec.porygon.entity.AreaAgricola;
 import fatec.porygon.entity.Cidade;
+import fatec.porygon.entity.Safra;
 import fatec.porygon.enums.StatusArea;
 import fatec.porygon.repository.AreaAgricolaRepository;
+import fatec.porygon.repository.SafraRepository;
 import fatec.porygon.utils.ConvertGeoJsonUtils;
 
 import org.locationtech.jts.geom.Geometry;
@@ -12,9 +14,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
 
 @Service
 public class AreaAgricolaService {
@@ -30,10 +34,19 @@ public class AreaAgricolaService {
         this.cidadeService = cidadeService;
     }
 
+    @Autowired
+    private SafraRepository safraRepository;
+
     @Transactional
     public AreaAgricolaDto criarAreaAgricola(AreaAgricolaDto areaAgricolaDto) {
         AreaAgricola areaAgricola = convertToEntity(areaAgricolaDto);
         AreaAgricola savedAreaAgricola = areaAgricolaRepository.save(areaAgricola);
+
+        Safra safra = new Safra();
+        safra.setDataCadastro(LocalDateTime.now());  
+
+        safraRepository.save(safra);
+
         return convertToDto(savedAreaAgricola);
     }
 
@@ -149,4 +162,3 @@ public class AreaAgricolaService {
     }
     
 }
-


### PR DESCRIPTION
#59
A tabela safra agora tem duas colunas novas: data de cadastro e data da última versão. Também foi feito um ajuste no backend pra registrar automaticamente a data de cadastro quando o arquivo de área agrícola é enviado.